### PR TITLE
feat: adjust module and moduleResolution defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0 - 2025-4-13
+
+This pull request includes updates to the `packages/lib/config.json` configuration file to change the module resolution strategy.
+Configuration updates:
+* [`packages/lib/config.json`](diffhunk://#diff-0c81b2177887592c6dc72ebc072fb2c3549bf853837d2f440c05e29ad6c8887dL4-R5): Changed the `moduleResolution` setting from `node` to `bundler` to align with the new module resolution strategy.
+
+
 # 1.13.11 - 2025-4-13
 
 Here you specify what exactly will be added to the changelog of the new version.

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0 - 2025-4-13
+
+This pull request includes updates to the `packages/lib/config.json` configuration file to change the module resolution strategy.
+Configuration updates:
+* [`packages/lib/config.json`](diffhunk://#diff-0c81b2177887592c6dc72ebc072fb2c3549bf853837d2f440c05e29ad6c8887dL4-R5): Changed the `moduleResolution` setting from `node` to `bundler` to align with the new module resolution strategy.
+
+
 # 1.13.11 - 2025-4-13
 
 Here you specify what exactly will be added to the changelog of the new version.

--- a/packages/lib/config.json
+++ b/packages/lib/config.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
     // Target and module settings
-    "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "DOM"],
     // Strictness & type checking
     "strict": true, // Enables all strict type-checking options below

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/tsconfig",
-  "version": "1.13.11",
+  "version": "2.0.0",
   "main": "index.json",
   "license": "MIT",
   "repository": "https://github.com/omariosouto/tsconfig",


### PR DESCRIPTION
## Changelog

This pull request includes updates to the `packages/lib/config.json` configuration file to change the module resolution strategy.

Configuration updates:

* [`packages/lib/config.json`](diffhunk://#diff-0c81b2177887592c6dc72ebc072fb2c3549bf853837d2f440c05e29ad6c8887dL4-R5): Changed the `moduleResolution` setting from `node` to `bundler` to align with the new module resolution strategy.
